### PR TITLE
Small Fixes

### DIFF
--- a/src/endpoints/create-order.js
+++ b/src/endpoints/create-order.js
@@ -21,10 +21,10 @@ const schema = Joi.object().keys({
 
 
 
-module.exports.has_account = async (event, context, callback) => {
+module.exports.create_order = async (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false; 
 
-  console.log('has account')
+  console.log('create_order')
 
   console.log(event.body)
 

--- a/src/endpoints/list-orders.js
+++ b/src/endpoints/list-orders.js
@@ -9,6 +9,8 @@ const schema = Joi.object().keys({
   jwt: Joi.string().required(),
 });
 
+let stripe = Stripe(process.env.STRIPE_KEY)
+
 module.exports.list_orders = async (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false; 
 


### PR DESCRIPTION
## Issues resolved:
- In the list orders endpoint, we're using `stripe` but this variable was not defined.
- The `create_order` was named `has_account`. Note that the `serverless.yml` was still referring to it as `create_order`.