### PR TITLE
Return shipping address

### DIFF
--- a/src/utils/lookup-account.js
+++ b/src/utils/lookup-account.js
@@ -19,10 +19,10 @@ const LookupAccount = async (jwt)=>{
   let stripeAddress = null
 
   if(findByEmail.data && findByEmail.data.length > 0){
-
-    customerStripeId = findByEmail.data[0].id
-    stripeSourceId = findByEmail.data[0].default_source
-    stripeAddress = findByEmail.data[0].address
+    const customer = findByEmail.data[0]
+    customerStripeId = customer.id
+    stripeSourceId = customer.default_source
+    stripeAddress = customer.shipping && customer.shipping.address
 
     debug('stripe keys', Object.keys(findByEmail.data[0]))
     debug('shipping address', stripeAddress)


### PR DESCRIPTION
## Issues resolved:
Turns out we're not saving the user's address, but the user's shipping address. On the `has_account` endpoint we were returning the user's address which will always be empty. There are multiple solutions to this. In this PR I'm simply returning the user's shipping address as the 'address' returned by the function `has_account`.

Docs: https://stripe.com/docs/api/customers/create?lang=node.