### PR TITLE
Never fail funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See: [example/client-api.ts](example/client-api.ts)
 
  * `FUND_GOAL` - The goal amount, defaults to $50,000
  * `FUND_ACCEPTING` - Is fund raising active? Defaults to `false`
+ * `FUND_PRE_TOTAL` - Incase we can't reach stripe, pre-cache a total in env
 
 ### Serverless
 

--- a/src/endpoints/attach-token.js
+++ b/src/endpoints/attach-token.js
@@ -19,33 +19,49 @@ module.exports.attach_token = async (event, context, callback) => {
 
   console.log(event.body)
 
-  const valid = Joi.attempt(
-    JSON.parse(event.body),
-    schema
-  )
+  try{
+    const valid = Joi.attempt(
+      JSON.parse(event.body),
+      schema
+    )
 
-  const accountInfo = await LookupAccount(valid.jwt)
+    const accountInfo = await LookupAccount(valid.jwt)
 
-  if(!accountInfo.customerId){  throw new Error('no stripe customer') }
-  if(!accountInfo.emailVerified){  throw new Error('not verified') }
+    if(!accountInfo.customerId){  throw new Error('no stripe customer') }
+    if(!accountInfo.emailVerified){  throw new Error('not verified') }
 
-  let card = null
+    let card = null
 
-  debug('setting default source/token for customer', accountInfo.customerId, accountInfo.email, valid.tokenId)
-  card = await stripe.customers.update(
-    accountInfo.customerId,
-    {source: valid.tokenId}
-  )
+    debug('setting default source/token for customer', accountInfo.customerId, accountInfo.email, valid.tokenId)
+    card = await stripe.customers.update(
+      accountInfo.customerId,
+      {source: valid.tokenId}
+    )
 
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
-    },
-    body: JSON.stringify({
-      tokenId: valid.tokenId
-    })
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        tokenId: valid.tokenId
+      })
+    }
+
+  } catch (e) {
+    debug('ERROR', e)
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        error: 'There was an error while accepting payment information.',
+      }),
+    }
+
   }
 }

--- a/src/endpoints/create-customer.js
+++ b/src/endpoints/create-customer.js
@@ -82,7 +82,7 @@ module.exports.create_customer = async (event, context, callback) => {
     }
 
   } catch (e) {
-    debug(e)
+    debug('ERROR', e)
     return {
       statusCode: 400,
       headers: {

--- a/src/endpoints/create-customer.js
+++ b/src/endpoints/create-customer.js
@@ -6,7 +6,7 @@ const moment = require('moment')
 const verifyJwt = require('../utils/verify-jwt')
 const LookupAccount = require('../utils/lookup-account')
 
-let stripe = Stripe(process.env.STRIPE_KEY)
+let stripe = Stripe(process.env.STRIPE_KEY, {maxNetworkRetries: 2})
 
 
 const schema = Joi.object().keys({

--- a/src/endpoints/funding-status.js
+++ b/src/endpoints/funding-status.js
@@ -7,7 +7,10 @@ const moment = require('moment')
 const FundAccepting = (process.env.FUND_ACCEPTING !== undefined) ? process.env.FUND_ACCEPTING == 'true' : false;
 const FundGoal = (process.env.FUND_GOAL !== undefined) ? process.env.FUND_GOAL : 50000;
 
+const FundCachedTotal = process.env.FUND_PRE_TOTAL || 0
+
 let stripe = Stripe(process.env.STRIPE_KEY)
+
 
 let cacheTotalAmount = undefined
 let lastUpdate = new moment()
@@ -50,7 +53,25 @@ const crawlOrderStatus = async () => {
   return totalAmount
 }
 
-crawlOrderStatus().then(debug)
+
+try{
+  crawlOrderStatus().then(total=>{
+
+    cacheTotalAmount = total
+    debug('total cached', crawlOrderStatus)
+
+  }).catch(err=>{
+
+    debug('failed to cache order totals', err)
+
+  })
+}catch(err){
+
+  debug('failed to cache order totals', err)
+
+}
+
+
 
 module.exports.funding_status = async (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false; 
@@ -87,16 +108,22 @@ module.exports.funding_status = async (event, context, callback) => {
 
   } catch (e) {
     debug('ERROR', e)
+
     return {
-      statusCode: 400,
+      statusCode: 200,
       headers: {
         'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
         'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
       },
       body: JSON.stringify({
-        error: 'There was an error getting status.',
-      }),
+        error: 'There was an error getting latest status.',
+        funding: FundCachedTotal,
+        goal: FundGoal,
+        accepting: FundAccepting,
+        start: moment().startOf('isoWeek').toDate(),
+        end: moment().endOf('isoWeek').toDate(),
+        ts: moment()
+      })
     }
-
   }
 }

--- a/src/endpoints/funding-status.js
+++ b/src/endpoints/funding-status.js
@@ -55,31 +55,48 @@ crawlOrderStatus().then(debug)
 module.exports.funding_status = async (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false; 
 
-  const deltaTime = Math.abs( moment().diff(lastUpdate, 'seconds') )
+  try{
+    const deltaTime = Math.abs( moment().diff(lastUpdate, 'seconds') )
 
-  if(cacheTotalAmount === undefined || deltaTime > 60){
-    debug('update', deltaTime)
-    cacheTotalAmount = await crawlOrderStatus()
-    lastUpdate = new moment()
-  }
-  else{
-    debug('from cache')
-  }
-  
+    if(cacheTotalAmount === undefined || deltaTime > 60){
+      debug('update', deltaTime)
+      cacheTotalAmount = await crawlOrderStatus()
+      lastUpdate = new moment()
+    }
+    else{
+      debug('from cache')
+    }
+    
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
-    },
-    body: JSON.stringify({
-      funding: cacheTotalAmount,
-      goal: FundGoal,
-      accepting: FundAccepting,
-      start: moment().startOf('isoWeek').toDate(),
-      end: moment().endOf('isoWeek').toDate(),
-      ts: moment()
-    })
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        funding: cacheTotalAmount,
+        goal: FundGoal,
+        accepting: FundAccepting,
+        start: moment().startOf('isoWeek').toDate(),
+        end: moment().endOf('isoWeek').toDate(),
+        ts: moment()
+      })
+    }
+
+
+  } catch (e) {
+    debug('ERROR', e)
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        error: 'There was an error getting status.',
+      }),
+    }
+
   }
 }

--- a/src/endpoints/has-account.js
+++ b/src/endpoints/has-account.js
@@ -1,6 +1,5 @@
 const Joi = require('@hapi/joi')
 const debug = require('debug')('has-account')
-const Stripe = require('stripe')
 const moment = require('moment')
 
 const LookupAccount = require('../utils/lookup-account')

--- a/src/endpoints/has-account.js
+++ b/src/endpoints/has-account.js
@@ -16,19 +16,37 @@ module.exports.has_account = async (event, context, callback) => {
 
   debug(event.body)
 
-  const valid = Joi.attempt(
-    JSON.parse(event.body),
-    schema
-  )
+  try{
 
-  const accountInfo = await LookupAccount(valid.jwt)
+    const valid = Joi.attempt(
+      JSON.parse(event.body),
+      schema
+    )
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
-    },
-    body: JSON.stringify(accountInfo)
+    const accountInfo = await LookupAccount(valid.jwt)
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify(accountInfo)
+    }
+
+
+  } catch (e) {
+    debug('ERROR', e)
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        error: 'There was an error finding your account.',
+      }),
+    }
+
   }
 }

--- a/src/endpoints/list-orders.js
+++ b/src/endpoints/list-orders.js
@@ -18,27 +18,45 @@ module.exports.list_orders = async (event, context, callback) => {
 
   console.log(event.body)
 
-  const valid = Joi.attempt(
-    JSON.parse(event.body),
-    schema
-  )
+  try{
 
-  const accountInfo = await LookupAccount(valid.jwt)
+    const valid = Joi.attempt(
+      JSON.parse(event.body),
+      schema
+    )
 
-  if(!accountInfo.customerId){  throw new Error('no stripe customer') }
-  if(!accountInfo.emailVerified){  throw new Error('not verified') }
+    const accountInfo = await LookupAccount(valid.jwt)
 
-  const orders = await stripe.orders.list({
-    limit: 25,
-    customer: accountInfo.customerId
-  })
+    if(!accountInfo.customerId){  throw new Error('no stripe customer') }
+    if(!accountInfo.emailVerified){  throw new Error('not verified') }
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
-    },
-    body: JSON.stringify(orders)
+    const orders = await stripe.orders.list({
+      limit: 25,
+      customer: accountInfo.customerId
+    })
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify(orders)
+    }
+
+
+  } catch (e) {
+    debug('ERROR', e)
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        error: 'There was an error while listing orders.',
+      }),
+    }
+
   }
 }

--- a/src/endpoints/mailing-list.js
+++ b/src/endpoints/mailing-list.js
@@ -39,35 +39,53 @@ module.exports.mailing_list = async (event, context, callback) => {
 
   console.log(event.body)
 
-  const valid = Joi.attempt(
-    JSON.parse(event.body),
-    schema
-  )
-
-  
-  let subscribeStatus = false
   try{
-    subscribeStatus = await SendySubscribe(valid.email)
-  }
-  catch(err){
-    if(subscribeStatus instanceof Error){
-      subscribeStatus = err.message
-    } else {
-      subscribeStatus = err
+
+    const valid = Joi.attempt(
+      JSON.parse(event.body),
+      schema
+    )
+
+    
+    let subscribeStatus = false
+    try{
+      subscribeStatus = await SendySubscribe(valid.email)
     }
-  }
+    catch(err){
+      if(subscribeStatus instanceof Error){
+        subscribeStatus = err.message
+      } else {
+        subscribeStatus = err
+      }
+    }
 
-  debug(subscribeStatus)
+    debug(subscribeStatus)
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
-    },
-    body: JSON.stringify({
-      joined: subscribeStatus === true,
-      error: (subscribeStatus !== true ? subscribeStatus : null)
-    })
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        joined: subscribeStatus === true,
+        error: (subscribeStatus !== true ? subscribeStatus : null)
+      })
+    }
+
+
+  } catch (e) {
+    debug('ERROR', e)
+    return {
+      statusCode: 400,
+      headers: {
+        'Access-Control-Allow-Origin': process.env.CORS_ORIGIN, // Required for CORS support to work
+        'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      },
+      body: JSON.stringify({
+        error: 'There was an error during mailing list signup.',
+      }),
+    }
+
   }
 }

--- a/src/endpoints/mailing-list.js
+++ b/src/endpoints/mailing-list.js
@@ -1,10 +1,8 @@
 const Joi = require('@hapi/joi')
 const debug = require('debug')('mailing-list')
-const Stripe = require('stripe')
 const moment = require('moment')
 const Sendy = require('sendy-api')
 
-let stripe = Stripe(process.env.STRIPE_KEY)
 let sendy = new Sendy(process.env.SENDY_URL, process.env.SENDY_KEY)
 const SendyList = process.env.SENDY_LIST
 


### PR DESCRIPTION
## Issues resolved:

- [x] Funding calls should never fail. Fail over to always returning ENV parameter values if stripe failes
- [x] Handle more errors in cache priming call
- [x] Ensure all error responses have proper CORS headers

<!-- 
## Screenshot (optional)
 

## Test (optional)

-->
